### PR TITLE
Add Initial Status Properties

### DIFF
--- a/olm/jiraoperator.csv.yaml
+++ b/olm/jiraoperator.csv.yaml
@@ -89,9 +89,13 @@ spec:
         - kind: Service
           version: v1
       specDescriptors:
-        - description: The desired hostname for ingress to the Jira cluster.
+        - description: The desired hostname for accessing the application.
           displayName: Host
           path: ingress.host
         - description: Limits describes the minimum/maximum amount of compute resources required/allowed
           displayName: Resource Requirements
           path: pod.resources
+      statusDescriptors:
+        - description: The URI for accessing the application.
+          displayName: Endpoint
+          path: endpoint

--- a/pkg/apis/jira/v1alpha1/types.go
+++ b/pkg/apis/jira/v1alpha1/types.go
@@ -171,4 +171,7 @@ func (j *Jira) IsPVEnabled() bool {
 type JiraStatus struct {
 	// ServiceName is the LB service for accessing Jira.
 	ServiceName string `json:"serviceName,omitempty"`
+
+	// Endpoint is the URI for accessing Jira.
+	Endpoint string `json:"endpoint,omitempty"`
 }

--- a/pkg/apis/jira/v1alpha1/types.go
+++ b/pkg/apis/jira/v1alpha1/types.go
@@ -174,9 +174,12 @@ func (j *Jira) IsPVEnabled() bool {
 
 // JiraStatus resource
 type JiraStatus struct {
+	// Endpoint is the URI for accessing Jira.
+	Endpoint string `json:"endpoint,omitempty"`
+
 	// ServiceName is the LB service for accessing Jira.
 	ServiceName string `json:"serviceName,omitempty"`
 
-	// Endpoint is the URI for accessing Jira.
-	Endpoint string `json:"endpoint,omitempty"`
+	// State is the current state for the Jira application (Initializing, Running, etc...).
+	State string `json:"state"`
 }

--- a/pkg/apis/jira/v1alpha1/types.go
+++ b/pkg/apis/jira/v1alpha1/types.go
@@ -24,8 +24,8 @@ import (
 const (
 	// DefaultBaseImage is the default docker image to use for JIRA Pods.
 	DefaultBaseImage = "cptactionhank/atlassian-jira-software"
-	// DefaultBaseImageVersion is the default version to use for JIRA Pods.
-	DefaultBaseImageVersion = "7.10.2"
+	// DefaultVersion is the default Jira version to use for JIRA Pods.
+	DefaultVersion = "7.10.2"
 	// DefaultDataMountPath is the default filesystem path for JIRA Home.
 	DefaultDataMountPath = "/var/atlassian/jira"
 )
@@ -73,8 +73,8 @@ type JiraSpec struct {
 	// BaseImage image to use for a JIRA deployment.
 	BaseImage string `json:"baseImage"`
 
-	// BaseImageVersion is the version of base image to use.
-	BaseImageVersion string `json:"baseImageVersion"`
+	// Version is the Jira version to deploy.
+	Version string `json:"version"`
 
 	// DataMountPath path for JIRA Home.
 	DataMountPath string `json:"dataMountPath"`
@@ -100,8 +100,8 @@ func (j *Jira) SetDefaults() bool {
 		j.Spec.BaseImage = DefaultBaseImage
 		changed = true
 	}
-	if len(j.Spec.BaseImageVersion) == 0 {
-		j.Spec.BaseImageVersion = DefaultBaseImageVersion
+	if len(j.Spec.Version) == 0 {
+		j.Spec.Version = DefaultVersion
 		changed = true
 	}
 	if len(j.Spec.ConfigMapName) == 0 {
@@ -169,5 +169,6 @@ func (j *Jira) IsPVEnabled() bool {
 
 // JiraStatus resource
 type JiraStatus struct {
-	// Fill me
+	// ServiceName is the LB service for accessing Jira.
+	ServiceName string `json:"serviceName,omitempty"`
 }

--- a/pkg/apis/jira/v1alpha1/types.go
+++ b/pkg/apis/jira/v1alpha1/types.go
@@ -24,10 +24,15 @@ import (
 const (
 	// DefaultBaseImage is the default docker image to use for JIRA Pods.
 	DefaultBaseImage = "cptactionhank/atlassian-jira-software"
+
 	// DefaultVersion is the default Jira version to use for JIRA Pods.
 	DefaultVersion = "7.10.2"
+
 	// DefaultDataMountPath is the default filesystem path for JIRA Home.
 	DefaultDataMountPath = "/var/atlassian/jira"
+
+	// DefaultIngressPath is the default path for the Ingress resource.
+	DefaultIngressPath = "/"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -132,7 +137,7 @@ func (j *Jira) SetIngressDefaults() bool {
 		j.Spec.Ingress.Host = j.ObjectMeta.Name
 	}
 	if len(j.Spec.Ingress.Path) == 0 {
-		j.Spec.Ingress.Path = "/"
+		j.Spec.Ingress.Path = DefaultIngressPath
 	}
 	if len(j.Spec.Ingress.SecretName) == 0 {
 		j.Spec.Ingress.SecretName = fmt.Sprintf("%s-ingress", j.ObjectMeta.Name)

--- a/pkg/jira/pod.go
+++ b/pkg/jira/pod.go
@@ -178,7 +178,7 @@ func newPodSpec(j *v1alpha1.Jira) v1.PodSpec {
 func podContainers(j *v1alpha1.Jira) []v1.Container {
 	return []v1.Container{{
 		Env:           containerEnv(j),
-		Image:         fmt.Sprintf("%s:%s", j.Spec.BaseImage, j.Spec.BaseImageVersion),
+		Image:         fmt.Sprintf("%s:%s", j.Spec.BaseImage, j.Spec.Version),
 		LivenessProbe: containerLivenessProbe(j),
 		Name:          DefaultContainerName,
 		Ports: []v1.ContainerPort{{

--- a/pkg/jira/reconcile.go
+++ b/pkg/jira/reconcile.go
@@ -75,6 +75,10 @@ func (r *Reconciler) Reconcile(jr *v1alpha1.Jira) (err error) {
 		return
 	}
 
+	if err = updateStatus(r.resource, r.sdk); err != nil {
+		return
+	}
+
 	log.Debugf("finished reconciling resource: %s", jr.ObjectMeta.Name)
 	return nil
 }

--- a/pkg/jira/reconcile.go
+++ b/pkg/jira/reconcile.go
@@ -48,6 +48,7 @@ func (r *Reconciler) Reconcile(jr *v1alpha1.Jira) (err error) {
 	changed := r.resource.SetDefaults()
 	if changed {
 		log.Debug("simulating initializer")
+		r.resource.Status.State = StateInitializing
 		return r.sdk.Update(r.resource)
 	}
 
@@ -75,7 +76,7 @@ func (r *Reconciler) Reconcile(jr *v1alpha1.Jira) (err error) {
 		return
 	}
 
-	if err = updateStatus(r.resource, r.sdk); err != nil {
+	if err = processStatus(r.resource, r.sdk); err != nil {
 		return
 	}
 

--- a/pkg/jira/reconcile_test.go
+++ b/pkg/jira/reconcile_test.go
@@ -146,6 +146,7 @@ func TestReconcileSetDefaultsNotChanged(t *testing.T) {
 
 	sdk := new(MockSDK)
 	sdk.On("Get", mock.Anything).Return(nil)
+	sdk.On("Update", mock.Anything).Return(nil)
 
 	r := NewReconciler(sdk)
 	err := r.Reconcile(jira)

--- a/pkg/jira/reconcile_test.go
+++ b/pkg/jira/reconcile_test.go
@@ -128,7 +128,7 @@ func TestReconcileSetDefaultsNotChanged(t *testing.T) {
 	scName := "test-storage-class-name"
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test-base-image"
-	jira.Spec.BaseImageVersion = "test-base-image-version"
+	jira.Spec.Version = "test-base-image-version"
 	jira.Spec.ConfigMapName = "test-configmap-name"
 	jira.Spec.DataMountPath = "test-data-mount-path"
 	jira.Spec.Ingress = &v1alpha1.JiraIngressPolicy{
@@ -167,7 +167,7 @@ func TestReconcileHandlesNilObject(t *testing.T) {
 func TestReconcileHandleConfigMapError(t *testing.T) {
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"
@@ -187,7 +187,7 @@ func TestReconcileHandleConfigMapError(t *testing.T) {
 func TestReconcileHandleIngressError(t *testing.T) {
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"
@@ -213,7 +213,7 @@ func TestReconcileHandleIngressError(t *testing.T) {
 func TestReconcileHandleIngressSecretError(t *testing.T) {
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"
@@ -239,7 +239,7 @@ func TestReconcileHandleIngressSecretError(t *testing.T) {
 func TestReconcileHandlePodError(t *testing.T) {
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"
@@ -260,7 +260,7 @@ func TestReconcileHandlePVCError(t *testing.T) {
 	scName := "test"
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"
@@ -285,7 +285,7 @@ func TestReconcileHandlePVCError(t *testing.T) {
 func TestReconcileHandleServiceError(t *testing.T) {
 	jira := new(v1alpha1.Jira)
 	jira.Spec.BaseImage = "test"
-	jira.Spec.BaseImageVersion = "test"
+	jira.Spec.Version = "test"
 	jira.Spec.ConfigMapName = "test"
 	jira.Spec.DataMountPath = "test"
 	jira.Spec.SecretName = "test"

--- a/pkg/jira/reconcile_test.go
+++ b/pkg/jira/reconcile_test.go
@@ -153,7 +153,7 @@ func TestReconcileSetDefaultsNotChanged(t *testing.T) {
 
 	assert.Nil(t, err)
 	sdk.AssertExpectations(t)
-	sdk.AssertNumberOfCalls(t, "Get", 6)
+	sdk.AssertNumberOfCalls(t, "Get", 7)
 }
 
 // TestReconcileHandlesNilObject verifies that a nil Jira value produces an error.

--- a/pkg/jira/status.go
+++ b/pkg/jira/status.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Jira Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jira
+
+import (
+	"reflect"
+
+	"github.com/coreos/jira-operator/pkg/apis/jira/v1alpha1"
+	log "github.com/sirupsen/logrus"
+)
+
+func updateStatus(j *v1alpha1.Jira, s OperatorSDK) error {
+	status := v1alpha1.JiraStatus{
+		ServiceName: j.ObjectMeta.Name,
+	}
+
+	// don't update the status if there aren't any changes.
+	if reflect.DeepEqual(j.Status, status) {
+		return nil
+	}
+
+	log.Debugf("updating status for resource: %s", j.Name)
+	j.Status = status
+	return s.Update(j)
+}

--- a/pkg/jira/status.go
+++ b/pkg/jira/status.go
@@ -43,7 +43,7 @@ func updateStatus(j *v1alpha1.Jira, s OperatorSDK) error {
 func formatEndpoint(j *v1alpha1.Jira) string {
 	scheme := "http"
 	host := fmt.Sprintf("%s:%d", j.Name, DefaultServicePort)
-	path := "/"
+	path := v1alpha1.DefaultIngressPath
 
 	if j.IsIngressEnabled() {
 		host = j.Spec.Ingress.Host

--- a/pkg/jira/status.go
+++ b/pkg/jira/status.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// updateStatus will update the status properties for the Jira resource.
 func updateStatus(j *v1alpha1.Jira, s OperatorSDK) error {
 	status := v1alpha1.JiraStatus{
 		ServiceName: j.ObjectMeta.Name,
@@ -38,6 +39,7 @@ func updateStatus(j *v1alpha1.Jira, s OperatorSDK) error {
 	return s.Update(j)
 }
 
+// formatEndpoint will return the URI for accessing the application.
 func formatEndpoint(j *v1alpha1.Jira) string {
 	scheme := "http"
 	host := fmt.Sprintf("%s:%d", j.Name, DefaultServicePort)

--- a/pkg/jira/status_test.go
+++ b/pkg/jira/status_test.go
@@ -1,0 +1,15 @@
+// Copyright 2018 Jira Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jira

--- a/pkg/jira/status_test.go
+++ b/pkg/jira/status_test.go
@@ -13,3 +13,102 @@
 // limitations under the License.
 
 package jira
+
+import (
+	"testing"
+
+	"github.com/coreos/jira-operator/pkg/apis/jira/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFormatEndpointWithoutIngress(t *testing.T) {
+	j := &v1alpha1.Jira{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jira",
+			Namespace: "test-jira-namespace",
+		},
+	}
+
+	e := formatEndpoint(j)
+
+	assert.NotNil(t, e)
+	assert.Equal(t, "http://test-jira:8080/", e)
+}
+
+func TestFormatEndpointIngressWithoutTLS(t *testing.T) {
+	j := &v1alpha1.Jira{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jira",
+			Namespace: "test-jira-namespace",
+		},
+		Spec: v1alpha1.JiraSpec{
+			Ingress: &v1alpha1.JiraIngressPolicy{
+				Host: "test-ingress-host",
+			},
+		},
+	}
+
+	e := formatEndpoint(j)
+
+	assert.NotNil(t, e)
+	assert.Equal(t, "http://test-ingress-host", e)
+}
+
+func TestFormatEndpointIngressTLS(t *testing.T) {
+	j := &v1alpha1.Jira{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jira",
+			Namespace: "test-jira-namespace",
+		},
+		Spec: v1alpha1.JiraSpec{
+			Ingress: &v1alpha1.JiraIngressPolicy{
+				Host: "test-ingress-host",
+				TLS:  true,
+			},
+		},
+	}
+
+	e := formatEndpoint(j)
+
+	assert.NotNil(t, e)
+	assert.Equal(t, "https://test-ingress-host", e)
+}
+
+func TestFormatEndpointIngressPath(t *testing.T) {
+	j := &v1alpha1.Jira{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jira",
+			Namespace: "test-jira-namespace",
+		},
+		Spec: v1alpha1.JiraSpec{
+			Ingress: &v1alpha1.JiraIngressPolicy{
+				Host: "test-ingress-host",
+				Path: "/test-path",
+			},
+		},
+	}
+
+	e := formatEndpoint(j)
+
+	assert.NotNil(t, e)
+	assert.Equal(t, "http://test-ingress-host/test-path", e)
+}
+
+func TestFormatEndpointIngressWithDefaults(t *testing.T) {
+	j := &v1alpha1.Jira{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jira",
+			Namespace: "test-jira-namespace",
+		},
+		Spec: v1alpha1.JiraSpec{
+			Ingress: &v1alpha1.JiraIngressPolicy{},
+		},
+	}
+
+	j.SetDefaults()
+	e := formatEndpoint(j)
+
+	assert.NotNil(t, e)
+	assert.Equal(t, "http://test-jira/", e)
+}


### PR DESCRIPTION
This PR adds three initial status properties to the operator.

- **Endpoint**: The URI for accessing the Jira application either in-cluster or through Ingress depending on configuration.
- **ServiceName**: The name of the Service resource for the Jira application.
- **State**: The state of the Jira application. Currently one of either "Initializing", "Available" or "Unavailable".